### PR TITLE
Build process is using .eslintrc.json file now. Before it sticked to …

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+EXTEND_ESLINT=true

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ To get started:
 
 To run the tests:
 - `yarn run test`
+
+To run the linter:
+- `yarn run lint`

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint ./src"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Made `yarn build` respect `.eslintrc.json` configuration.

Default Create React App setup uses it's own ESLint configuration, and ignores `.eslintrc.json` file in the project. That leads to unenforced linting rules on the build time.

Details:
https://create-react-app.dev/docs/setting-up-your-editor/#experimental-extending-the-eslint-config